### PR TITLE
Add a red line for all pages under header

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,6 +3,8 @@ import CharacterContainer from "../CharacterContainer/CharacterContainer";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import CharacterDetails from "../CharacterDetails/CharacterDetails";
 import Header from "../Header/Header";
+import TeamOne from "../TeamOne/TeamOne";
+
 
 const App = () => {
   return (
@@ -25,14 +27,14 @@ const App = () => {
               <Header showHomeButton={true} showTeamButton={true} />
               <CharacterDetails />
             </>
-          }
+          } 
         />
         <Route
           path='/team'
           element={
             <>
               <Header showHomeButton={true} showTeamButton={false} />
-              {/* <CharacterDetails /> */}
+              <TeamOne />
             </>
           }
         />

--- a/src/components/CharacterDetails/CharacterDetails.css
+++ b/src/components/CharacterDetails/CharacterDetails.css
@@ -10,3 +10,10 @@ p {
 .character-details {
   border: solid 5px white
 }
+
+.line {
+  width: 100%;
+  height: 3px;  
+  background-color: #FF4654;;
+  margin: 0 20px;
+}

--- a/src/components/CharacterDetails/CharacterDetails.js
+++ b/src/components/CharacterDetails/CharacterDetails.js
@@ -37,6 +37,7 @@ const CharacterDetails = () => {
 
   return (
     <div className='single-character-page'>
+      <div className='line'></div>
       <div className='character-details'>
         <img src={character.fullPortrait} className='character-full-portrait' />
         <p className='single-character-name'>

--- a/src/components/TeamOne/TeamOne.css
+++ b/src/components/TeamOne/TeamOne.css
@@ -1,0 +1,6 @@
+.line {
+  width: 100%;
+  height: 3px;  
+  background-color: #FF4654;;
+  margin: 0 20px;
+}

--- a/src/components/TeamOne/TeamOne.js
+++ b/src/components/TeamOne/TeamOne.js
@@ -1,0 +1,11 @@
+import "./TeamOne.css";
+
+const TeamOne = () => {
+  return (
+    <div className="team-one-container">
+      <div className='line'></div>
+    </div>
+  );
+};
+
+export default TeamOne


### PR DESCRIPTION
### Did this break anything?
- [x]  No
- [ ]  Yes
### Type of change
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: index.html, Card.css, Card.js, CharacterContainer.css, header.css
- Short description of changes: add red line under header for every page
<img width="1417" alt="Screenshot 2023-11-07 at 10 14 21 PM" src="https://github.com/Nicolelam8891/valorantshowcase/assets/132624450/88fcbc39-96f5-4160-be7d-60129472b7bf">
