### PR TITLE
Fixed bug when user clicks on Add to Team displaying on all characters

### DIFF
--- a/cypress/e2e/individualPage.cy.js
+++ b/cypress/e2e/individualPage.cy.js
@@ -100,20 +100,47 @@ describe("Show selected character user flow", () => {
       cy.get(":nth-child(4) > .ability-description").contains(
         "p",
         "EQUIP Thrash. FIRE to link with Thrash’s mind and steer her through enemy territory. ACTIVATE to lunge forward and explode, Detaining any players in a small radius. When Thrash expires she reverts into a dormant globule. INTERACT to reclaim the globule and gain another Thrash charge after a short cooldown. Thrash can be reclaimed once."
-      )
-      cy.get('.character-full-portrait-container')
-      cy.get('.character-full-portrait')
-      .should("have.attr", "src")
-      .should(
-        "eq",
-        "https://media.valorant-api.com/agents/e370fa57-4757-3604-3648-499e1f642d3f/fullportrait.png"
+      );
+      cy.get(".character-full-portrait-container");
+      cy.get(".character-full-portrait")
+        .should("have.attr", "src")
+        .should(
+          "eq",
+          "https://media.valorant-api.com/agents/e370fa57-4757-3604-3648-499e1f642d3f/fullportrait.png"
         );
-        cy.get('.character-full-portrait-container')
-        cy.get('.add-to-team-button').contains('Add to Team').click()
-        cy.get('.team-confirmation-message')
-        .contains('Character added successfully!')
-        cy.get('.add-to-team-button').contains('Add to Team').click()
-        cy.get('.team-error-message').contains('').This character has already been added to the team. Please select another.
+      cy.get(".character-full-portrait-container");
+      cy.get(".add-to-team-button").contains("Add to Team").click();
+      cy.get(".team-confirmation-message").contains(
+        "Character added successfully!"
+      );
+      cy.get(".add-to-team-button").contains("Add to Team").click();
+      cy.get(".team-error-message").contains(
+        "This character has already been added to the team. Please select another."
+      );
+      cy.get("header");
+      cy.get('[href="/team"]')
+        .get(".team-button")
+        .contains("TEAM")
+        .click()
+        .url()
+        .should("eq", "http://localhost:3000/team");
+      cy.get("header")
+        .get(".valorant-logo")
+        .get(".line")
+        .get(".home-button")
+        .contains("HOME");
+      cy.get(".team-one-container");
+      cy.get(".display-icon-image-card");
+      cy.get(".display-icon-image")
+        .should("have.attr", "src")
+        .should(
+          "eq",
+          "https://media.valorant-api.com/agents/e370fa57-4757-3604-3648-499e1f642d3f/displayiconsmall.png"
+        );
+      cy.get(".team-icon-info");
+      cy.get(".character-name").contains("p", "Gekko");
+      cy.get(".character-role").contains("p", "Role: Initiator");
+      cy.get(".delete-button").contains("❌");
     });
   });
 });

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -108,6 +108,8 @@ const App = () => {
                 addToTeam={addToTeam}
                 errorMessage={errorMessage}
                 confirmationMessage={confirmationMessage}
+                setConfirmationMessage={setConfirmationMessage}
+                setErrorMessage={setErrorMessage}
               />
             </>
           }

--- a/src/components/CharacterDetails/CharacterDetails.js
+++ b/src/components/CharacterDetails/CharacterDetails.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import "./CharacterDetails.css";
 import { useParams } from "react-router-dom";
 
-const CharacterDetails = ({ addToTeam, errorMessage, confirmationMessage }) => {
+const CharacterDetails = ({ addToTeam, errorMessage, confirmationMessage, setConfirmationMessage, setErrorMessage }) => {
   const [character, setCharacter] = useState(null);
   const [error, setError] = useState("");
   const { id } = useParams();
@@ -26,6 +26,8 @@ const CharacterDetails = ({ addToTeam, errorMessage, confirmationMessage }) => {
 
   useEffect(() => {
     getCharacterDetail();
+    setErrorMessage('');
+    setConfirmationMessage('');
   }, [id]);
 
   if (error) {
@@ -82,7 +84,7 @@ const CharacterDetails = ({ addToTeam, errorMessage, confirmationMessage }) => {
               {character.abilities.map((ability) => (
                 <div className='ability-slots'>
                   <img
-                    class='ability-icon'
+                    className='ability-icon'
                     src={ability.displayIcon}
                     alt={ability.displayName}
                   />


### PR DESCRIPTION
### Did this break anything?
- [x]  No
- [ ]  Yes
### Type of change
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: individualPage.cy.js, App.js, CharacterDetails.js
- Short description of changes: Fixed the bug that was occurring on the individual character page. When a user clicks on Add to Page, all the correct error messages and feedback messages will populate; however, it will populate for ALL characters at the same time even though the user didn't press on the button. The but is fixed and there is still functionality. 